### PR TITLE
#4 Feature/squash specified number

### DIFF
--- a/localTest.sh
+++ b/localTest.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xe
+set -eo pipefail
+
+TESTDIR=test-git-fixup-$$
+
+mkdir -p $TESTDIR
+go build
+cp ./git-fixup $TESTDIR
+cd $TESTDIR
+
+:
+: prepare git
+:
+git init
+git config --local user.email "git-fixup@example.com"
+git config --local user.name "git fixup"
+git commit --allow-empty -m "Initial commit"
+
+:
+: prepare test
+:
+max=10
+for ((i=0; i <= $max; i++)); do
+    touch file-${i}
+    git add file-${i}
+    git commit -m "Add file-${i}"
+done
+
+
+git log --oneline
+./git-fixup -n 5
+git log --oneline
+git diff HEAD^..HEAD --name-only

--- a/localTest.sh
+++ b/localTest.sh
@@ -2,11 +2,12 @@
 set -xe
 set -eo pipefail
 
-TESTDIR=test-git-fixup-$$
+ExecComamnd=$(basename $(pwd))
+TESTDIR=test-${ExecComamnd}-$$
 
 mkdir -p $TESTDIR
 go build
-cp ./git-fixup $TESTDIR
+cp ./${ExecComamnd} $TESTDIR
 cd $TESTDIR
 
 :
@@ -29,6 +30,6 @@ done
 
 
 git log --oneline
-./git-fixup -n 5
+./${ExecComamnd} -n 5
 git log --oneline
 git diff HEAD^..HEAD --name-only

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -44,8 +43,8 @@ func main() {
 		} else {
 			fmt.Println("*** Do you fixup the following commits?(y/n) ***")
 			out, err := exec.Command("git", "log", "--oneline", "-n", num).Output()
-			fmt.Println(string(out))
 			if err != nil {
+				fmt.Print(out)
 				os.Exit(1)
 			}
 			for {
@@ -90,31 +89,47 @@ func main() {
 			}
 
 		default:
+			var commitHashList []string
+			var commitMsg []string
+			/* Get commit hash */
 			out, err := exec.Command("git", "log", "--oneline", "--format=%h").Output()
-
 			if err != nil {
 				fmt.Print(string(out))
 				fmt.Print(err)
 				os.Exit(1)
 			}
 
-			var commitHashList []string
-
 			for _, v := range regexp.MustCompile("\r\n|\n|\r").Split(string(out), -1) {
 				commitHashList = append(commitHashList, v)
 			}
+			/* (END)Get commit hash */
 
-			tests := []string{
-				"git",
+			/* Get commit message */
+			out, err = exec.Command("git", "log", "--oneline", "--format=%s").Output()
+			if err != nil {
+				fmt.Print(string(out))
+				fmt.Print(err)
+				os.Exit(1)
 			}
-			for _, test := range tests {
-				if k, err := exec.LookPath(test); err != nil {
-					fmt.Println(k)
-					log.Print(err)
+			for _, v := range regexp.MustCompile("\r\n|\n|\r").Split(string(out), -1) {
+				commitMsg = append(commitMsg, v)
+			}
+			/* (END)Get commit message */
+
+			/* Display commit hash and message. The [pickup|..] strings is colored */
+			for i := 0; i < len(commitMsg)-1; i++ {
+
+				/* (WIP) Switch output corresponded to do squash */
+				if i > 1 && i < 8 {
+					fmt.Printf("[%2d] \x1b[35mpickup\x1b[0m -> \x1b[36msquash\x1b[0m %s\tsquash! %s\n", i, commitHashList[i], commitMsg[i])
+				} else {
+					fmt.Printf("[%2d] \x1b[35mpickup\x1b[0m -> \x1b[35mpickup\x1b[0m %s\t%s\n", i, commitHashList[i], commitMsg[i])
 				}
-
 			}
+			/* (END)Display commit hash and message */
+			os.Exit(1) // This line will be removed.
 
+			/* (WIP) */
 			for i := 0; i < number; i++ {
 				fixUpStr := fmt.Sprintf("--squash=%s", commitHashList[i])
 				cmd := exec.Command("git", "commit", fixUpStr)
@@ -126,6 +141,7 @@ func main() {
 					os.Exit(1)
 				}
 			}
+			/* (END) */
 
 			// rebase
 			os.Setenv("GIT_EDITOR", ":")

--- a/main.go
+++ b/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
+
+	"github.com/codegangsta/cli"
 )
 
 func main() {
@@ -87,8 +89,23 @@ func main() {
 			}
 
 		default:
-			// Only Disply
-			fmt.Println("number", number)
+			out, err := exec.Command("git", "log", "--oneline", "--format=%h").Output()
+
+			if err != nil {
+				fmt.Print(err)
+				os.Exit(1)
+			}
+
+			var commitHashList []string
+
+			for _, v := range regexp.MustCompile("\r\n|\n|\r").Split(string(out), -1) {
+				commitHashList = append(commitHashList, v)
+			}
+
+			for i := 0; i < number; i++ {
+				fmt.Println(commitHashList[i])
+			}
+
 		}
 
 		return nil


### PR DESCRIPTION
### 指定した値までを1つにまとめる処理を追加

`./git-fixup -n 5`


HEAD\~4からHEADのコミットをHEAD~5に統合する

```
[ 5] pickup -> pickup 046b139 Add file-5
[ 4] pickup -> squash aa935e9 squash! Add file-5
[ 3] pickup -> squash 1e4e5d8 squash! Add file-5
[ 2] pickup -> squash df85759 squash! Add file-5
[ 1] pickup -> squash c7515d2 squash! Add file-5
[ 0] pickup -> squash 7bb156e squash! Add file-5
```
### 確認方法
テストファイルを実行する
./localTest.sh 
シェル上で対話形式になったら、y を押下
( localTest.sh で yes|head -n 1|./git-fixup -n 5 すると、それ以降の確認のためのコマンドが効かなかったので、ここはキーボードでyを押下)




