### PR TITLE
[WIP]not use timeout command

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -200,7 +200,10 @@ test_signal_handling() {
   setup
   set +e
   REFLOG_HASH_1=$(git log --oneline --format=%h|head -n 1)
-  timeout -s ${SIGNAL} 3 ./"$EXEC_COMMAND" ${FLAGS} ${RANGE} | tee ${VALIDATION_FILE_ABS_PATH}
+  ./"$EXEC_COMMAND" -f -n 1..10 > "${VALIDATION_FILE_ABS_PATH}" &
+  sleep 1 # Wait for the qs command to be executed
+  kill -${SIGNAL} $!
+  sleep 1 # Wait for qs command to catch sigint
   RESULT=$(grep -c "${MESSAGE}" ${VALIDATION_FILE_ABS_PATH})
   REFLOG_HASH_2=$(git log --oneline --format=%h|head -n 1)
   rm ${VALIDATION_FILE_ABS_PATH}


### PR DESCRIPTION
close: https://github.com/kamontia/qs/issues/86

```
+ timeout -s 2 3 ./qs -f -n 1..10
+ tee /Users/take/go/src/github.com/kamontia/qs/tmp-2GtTh
./script/test.sh: line 203: timeout: command not found
++ grep -c 'Completed. Please rebase manually.' /Users/take/go/src/github.com/kamontia/qs/tmp-2GtTh
+ RESULT=0
++ git log --oneline --format=%h
++ head -n 1
+ REFLOG_HASH_2=ab7b5ac
+ rm /Users/take/go/src/github.com/kamontia/qs/tmp-2GtTh
+ set -e
+ [[ 0 -ne 0 ]]
+ echo '[failed] ./qs -f -n 1..10 EXPECTED MESSAGE Completed. Please rebase manually.'
```