### PR TITLE
Add make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: deps
 ## Cross build binaries
 cross-build:
 	rm -rf $(PKGDIR)
-	gox -os=$(GOXOS) -arch=$(GOXARCH) -output=$(GOXOUTPUT) 
+	gox -os=$(GOXOS) -arch=$(GOXARCH) -output=$(GOXOUTPUT) -ldflags "$(LDFLAGS)"
 
 .PHONY: package
 ## Make package

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+NAME := qs
+CURRENT := $(shell pwd)
+BUILDDIR=./build
+BINDIR=$(BUILDDIR)/bin
+PKGDIR=$(BUILDDIR)/pkg
+DISTDIR=$(BUILDDIR)/dist
+
+VERSION := $(shell git describe --tags --abbrev=0)
+LDFLAGS := -X 'main.version=$(VERSION)'
+GOXOS := "darwin windows linux"
+GOXARCH := "386 amd64"
+GOXOUTPUT := "$(PKGDIR)/$(NAME)_{{.OS}}_{{.Arch}}/{{.Dir}}"
+
+.PHONY: deps
+## Install dependencies
+deps:
+	$(GOGET) golang.org/x/tools/cmd/goimports
+	$(GOGET) github.com/golang/lint/golint
+	$(GOGET) github.com/urfave/cli
+	$(GOGET) github.com/mitchellh/go-homedir
+	$(GOGET) github.com/Songmu/make2help/cmd/make2help
+	$(GOGET) github.com/tcnksm/ghr
+	$(GOGET) github.com/mitchellh/gox
+
+.PHONY: build
+## Build binaries
+build: deps
+	go build -ldflags "$(LDFLAGS)" -o $(BINDIR)/$(NAME)
+
+.PHONY: cross-build
+## Cross build binaries
+cross-build:
+	rm -rf $(PKGDIR)
+	gox -os=$(GOXOS) -arch=$(GOXARCH) -output=$(GOXOUTPUT) 
+
+.PHONY: package
+## Make package
+package: cross-build
+	rm -rf $(DISTDIR)
+	mkdir $(DISTDIR)
+	pushd $(PKGDIR) > /dev/null && \
+		for P in `ls | xargs basename`; do zip -r $(CURRENT)/$(DISTDIR)/$$P.zip $$P; done && \
+		popd > /dev/null
+
+.PHONY: release
+## Release package to Github
+release: package
+	ghr $(VERSION) $(DISTDIR)
+
+.PHONY: test
+## Run tests
+test: deps
+	$(GOTEST) -v ./...
+
+.PHONY: lint
+## Lint
+lint: deps
+	go vet ./...
+	golint ./...
+
+.PHONY: fmt
+## Format source codes
+fmt: deps
+	find . -name "*.go" -not -path "./vendor/*" | xargs goimports -w
+
+.PHONY: clean
+clean:
+	$(GOCLEAN)
+	rm -rf $(BUILDDIR)
+
+.PHONY: help
+## Show help
+help:
+	@make2help $(MAKEFILE_LIST)


### PR DESCRIPTION
I create Makefile.

```
kamo@kamobookPro: make cross-build
rm -rf ./build/pkg
gox -os="darwin windows linux" -arch="386 amd64" -output="./build/pkg/qs_{{.OS}}_{{.Arch}}/{{.Dir}}" -ldflags "-X 'main.version=v0.2.0'"
Number of parallel builds: 7

-->      darwin/386: _/Users/kamo/repo/github.com/kamontia/qs
-->       linux/386: _/Users/kamo/repo/github.com/kamontia/qs
-->    darwin/amd64: _/Users/kamo/repo/github.com/kamontia/qs
-->   windows/amd64: _/Users/kamo/repo/github.com/kamontia/qs
-->     linux/amd64: _/Users/kamo/repo/github.com/kamontia/qs
-->     windows/386: _/Users/kamo/repo/github.com/kamontia/qs
make cross-build  4.64s user 1.85s system 480% cpu 1.352 total

~/repo/github.com/kamontia/qs AddMakeFile*
kamo@kamobookPro: find ./build/pkg -type f|xargs file
./build/pkg/qs_darwin_amd64/qs:      Mach-O 64-bit executable x86_64
./build/pkg/qs_windows_386/qs.exe:   PE32 executable (console) Intel 80386 (stripped to external PDB), for MS Windows
./build/pkg/qs_darwin_386/qs:        Mach-O executable i386
./build/pkg/qs_windows_amd64/qs.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
./build/pkg/qs_linux_amd64/qs:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
./build/pkg/qs_linux_386/qs:         ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, not stripped
```

close #93 